### PR TITLE
Repairing the Likelihood

### DIFF
--- a/FitMain.R
+++ b/FitMain.R
@@ -33,11 +33,11 @@ nrep <- 1
 test <- datprep[16,] %>%
   mutate(fit_ga_MK_RNplus = mclapply(data, fit_one_vp_ga, rep = nrep, objective = ll_vp_full,
                                 model = "MK_RNplus", ll_fun = sim_fun_MK_RNplus,
-                                lower = lowerRNplus, upper = upperRNplus, mc.cores = 16, mc.preschedule = FALSE) )  %>% 
+                                lower = lowerRNplus, upper = upperRNplus, mc.cores = 1, mc.preschedule = FALSE) )  %>% 
   mutate(fit_nlminb_MK_RNplus = mclapply(data, fit_one_vp_nlminb, rep = nrep,
                                          startpar = fit_ga_MK_RNplus ,
                                          model = "MK_RNplus", objective = ll_vp_full, ll_fun = ll_vp3, type = "r",
-                                         lower = .Machine$double.eps, upper = Inf, mc.cores = 16, mc.preschedule = FALSE))
+                                         lower = .Machine$double.eps, upper = Inf, mc.cores = 1, mc.preschedule = FALSE))
 
 
 # load some GA fitted data

--- a/FitMain.R
+++ b/FitMain.R
@@ -55,16 +55,27 @@ fit_one_vp_nlminb(data = datprep[16,]$data[[1]],model = "MK_RNplus",
                   lower = .Machine$double.eps,rep = nrep,
                   startpar = restest2[16,]$fit_ga_MK_RNplus[[1]] %>% mutate(cvid = id,leftout=0))
 
-ll_vp_full(pars = pars,
+
+#### test smaller parts
+pars_tmp <- restest2[16,]$fit_ga_MK_RNplus[[1]] %>% 
+  mutate(cvid = id,leftout=0) %>% 
+  select(1:4) %>% 
+  slice(1) %>% 
+  unlist()
+
+dp_tmp <- prep_data(datprep[16,]$data[[1]])
+
+ll_vp_full(pars = pars_tmp,
            ll_fun = ll_vp3, type = "r",lower = 0,
-           set_sizes = dp$set_sizes, error_list = dp$datalist, model = "MK_RNplus")
+           set_sizes = dp_tmp$set_sizes, 
+           error_list = dp_tmp$datalist, model = "MK_RNplus")
 
 # for setsize 1
 ll_vp3(pars = pars, errors = errors, model = model,type=type)
 
 
 
-int_fun_MK_RNplus(c(0,1e2,1e5,1e6),pars,0.5)
+int_fun_MK_RNplus(c(0,1e2,1e3,1e4,1e5,1e6),pars_tmp,0.5)
 
 kappa <- 1e6
 

--- a/FittingAlgorithmsFunctions.R
+++ b/FittingAlgorithmsFunctions.R
@@ -57,14 +57,14 @@ fit_one_vp_nlminb <- function(model, data, startpar, rep, objective, ll_fun, low
   out_list <- vector("list", rep)
 
   #startpar <- data.frame(do.call(rbind, startpar))
-  startpar <- startpar %>% filter(cvid == dp$cvid) %>% select(names(get_start_vp(model)))
+  startpar <- startpar[[1]] %>% filter(cvid == dp$cvid) %>% select(names(get_start_vp(model)))
   startpar <- as.data.frame(startpar)
   
   for (i in seq_len(rep)) {
     
     tic <- Sys.time()
   
-    start <- as.vector(t(startpar[i,]))
+    start <- unlist(startpar)
 
     tmp <- tryCatch(nlminb(start, objective = objective, 
                            error_list = dp$datalist, set_sizes = dp$set_sizes, 
@@ -99,7 +99,7 @@ fit_one_vp_nlminb <- function(model, data, startpar, rep, objective, ll_fun, low
          , tibble (
           cvid = dp$cvid
          )
-        , start %>% #spread(enframe(start, "start"), start, value) %>%
+        , spread(enframe(start, "start"), start, value) %>%
           setNames(paste0("s_",names(get_start_vp(model))))
       )
     } 

--- a/FittingAlgorithmsFunctions.R
+++ b/FittingAlgorithmsFunctions.R
@@ -55,9 +55,17 @@ fit_one_vp_nlminb <- function(model, data, startpar, rep, objective, ll_fun, low
   
   dp <- prep_data(data)
   out_list <- vector("list", rep)
+  
+  if (is.data.frame(startpar)) {
+    startpar <- startpar %>% 
+      filter(cvid == dp$cvid) %>% 
+      select(names(get_start_vp(model))) %>% 
+      slice(1)
+  } else {
+    startpar <- startpar[[1]] %>% filter(cvid == dp$cvid) %>% select(names(get_start_vp(model)))
+  }
 
   #startpar <- data.frame(do.call(rbind, startpar))
-  startpar <- startpar[[1]] %>% filter(cvid == dp$cvid) %>% select(names(get_start_vp(model)))
   startpar <- as.data.frame(startpar)
   
   for (i in seq_len(rep)) {
@@ -71,7 +79,13 @@ fit_one_vp_nlminb <- function(model, data, startpar, rep, objective, ll_fun, low
                            ll_fun = ll_fun, model = model,..., 
                            type = type,
                            lower = .Machine$double.eps, upper = Inf,
-                           control = list(eval.max = 300, iter.max = 300, trace = 1)), error = function(e) NA)
+                           control = list(
+                             eval.max = 300, 
+                             iter.max = 300, 
+                             trace = 1,
+                             rel.tol = 1e-5, ## default 1e-10
+                             x.tol = 1.5e-5 ## default 1.5e-8
+                             )), error = function(e) NA)
     if (is.list(tmp)) {
       
       out_list[[i]] <- bind_cols(

--- a/OptimisationFunctions.R
+++ b/OptimisationFunctions.R
@@ -10,7 +10,7 @@ ll_vp_full <- function(pars, model, error_list, set_sizes, ll_fun, type,...) {
   
   out <- vector("numeric", length(set_sizes))
   for (i in seq_along(error_list)) {
-   i <- 1
+   #i <- 1
     out[[i]] <- ll_fun(pars = c(precision[i],parscont), 
                        errors = error_list[[i]],
                        model = model,

--- a/nlminbNumIntFunctions.R
+++ b/nlminbNumIntFunctions.R
@@ -9,11 +9,13 @@ int_fun_MK_RNplus <- function(x, pars, radian) {
     
     kc <- sqrt(pars[3]^2 + kappa^2 + 2 * pars[3]*kappa*cos(radian))
     
-    out[i] <- dgamma(kappa, shape = pars[1]/pars[2], scale = pars[2]) * 
-      ((besselI(kc,0,expon.scaled = TRUE) / 
+    out[i] <- dgamma(kappa, shape = pars[1]/pars[2], scale = pars[2]) 
+    if (out[i] != 0) {
+      out[i] <- out[i] * ((besselI(kc,0,expon.scaled = TRUE) / 
           (2*pi*besselI(kappa,0,expon.scaled = TRUE) * 
              besselI(pars[3],0,expon.scaled = TRUE))) *
          exp(kc - (kappa + pars[3])))
+    }
     
   }
   out


### PR DESCRIPTION
Main change: To solve the problem in integration, each iteration in the likelihood function returns 0 if `dgamma(kappa, shape = pars[1]/pars[2], scale = pars[2]) == 0`. The Bessel function is then only evaluated if this value is unequal to 0. This solves the `NaN` issue.

The second main change is that I reduced the tolerance in `nlminb`. That seems to be a lot faster given the known uncertainty in the likelihood.

I also made a few other changes so the code works both in the general form and the reduced example (i.e., in `fit_one_vp_nlminb`). 